### PR TITLE
[Badge] Add .htaccess to prevent image cache @open sesame 05/28 20:24

### DIFF
--- a/ci/badge/.htaccess
+++ b/ci/badge/.htaccess
@@ -1,0 +1,21 @@
+#Prevent the image caching in Github                                                                               
+<IfModule mod_headers.c>
+    Header set Cache-Control "no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Expires 0
+</IfModule>
+ 
+<FilesMatch "\.(css|flv|gif|htm|html|ico|jpe|jpeg|jpg|js|mp3|mp4|png|pdf|swf|txt)$">
+    <IfModule mod_expires.c>
+        ExpiresActive Off 
+    </IfModule>
+    <IfModule mod_headers.c>
+        FileETag None
+        Header unset ETag
+        Header unset Pragma
+        Header unset Cache-Control
+        Header unset Last-Modified
+        Header set Pragma "no-cache"
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    </IfModule>
+</FilesMatch>


### PR DESCRIPTION
Add .htaccess to prevent image cache Since GitHub caches image files, badge is not updated on the fly. 

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped