### PR TITLE
Fix/CI Build Error

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-clang.sh
+++ b/ci/taos/plugins-good/pr-prebuild-clang.sh
@@ -80,6 +80,9 @@ function pr-prebuild-clang(){
     done
     git diff ${search_target} > ../report/${clang_format_file}
 
+    # Revert what clang-format did to the source tree
+    git reset --hard
+
     # check a clang format rule with file size of patch file
     PATCHFILE_SIZE=$(stat -c%s ../report/${clang_format_file})
     if [[ $PATCHFILE_SIZE -ne 0 ]]; then


### PR DESCRIPTION
In older toolchains of Ubuntu, changing code style
generated build errors (order of headers relative to gstcheck.h)

Reset clang-format results before running other CI modules.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

