### PR TITLE
Remove pr-aduit-group.txt in bot messages. Fixes #637

### DIFF
--- a/ci/taos/plugins-staging/pr-postbuild-nnstreamer-ubuntu-apptest.sh
+++ b/ci/taos/plugins-staging/pr-postbuild-nnstreamer-ubuntu-apptest.sh
@@ -199,7 +199,7 @@ function pr-postbuild-nnstreamer-ubuntu-apptest-run-queue() {
         cibot_report $TOKEN "failure" "${BOT_NAME}/pr-postbuild-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         # Comment a hint on failed PR to author.
-        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/pr-aduit-group.txt"
+        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}"
         cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
 
         return ${result}
@@ -422,7 +422,7 @@ function pr-postbuild-nnstreamer-ubuntu-apptest-run-queue() {
         cibot_report $TOKEN "failure" "${BOT_NAME}/pr-postbuild-nnstreamer-apptest" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "$GITHUB_WEBHOOK_API/statuses/$input_commit"
 
         # comment a hint why a submitted PR is failed.
-        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/pr-aduit-group.txt"
+        message=":octocat: **cibot**: $user_id, apptest could not be completed. To find out the reasons, please go to ${CISERVER}/${PRJ_REPO_UPSTREAM}/ci/${dir_commit}"
         cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
     fi
 }


### PR DESCRIPTION
This patch removes pr-aduit-group.txt that doesn't exist anymore. The file link is replaced by the folder link.
In other words, `s/\/pr-aduit-group.txt//g`.

Discussion: #637

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nnstreamer/taos-ci/638)
<!-- Reviewable:end -->
