### PR TITLE
[Doxygen] Add missing extensions for cpp source codes

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-doxygen-build.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-build.sh
@@ -63,7 +63,7 @@ for i in ${FILELIST}; do
     if [[ `file $i | grep "ASCII text" | wc -l` -gt 0 ]]; then
         case $i in
             # In case of source code
-            *.c | *.cpp | *.h | *.hpp | *.py | *.sh | *.php | *.java)
+            *.c | *.cpp | *.cc | *.hh | *.h | *.hpp | *.py | *.sh | *.php | *.java)
                 echo -e "[DEBUG] ( $i ) file is a source code with a ASCII text format."
                 doxygen_analysis_sw="doxygen"
                 doxygen_analysis_rules=" - "
@@ -74,7 +74,7 @@ for i in ${FILELIST}; do
                 # Doxygen Usage: ( cat ../Doxyfile.ci ; echo "INPUT=./webhook.php" ) | doxygen -
                 ( cat $doxygen_analysis_config ; echo "INPUT=$i" ) | $doxygen_analysis_sw $doxygen_analysis_rules
                 result=$?
-                
+
                 if  [[ $result != 0 ]]; then
                     echo -e "[DEBUG] $doxygen_analysis_sw: failed. file name: $i, There are incorrect doxygen tag(s)."
                     check_result="failure"

--- a/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
@@ -40,14 +40,14 @@ function pr-prebuild-doxygen-tag(){
             echo "[DEBUG] Doxygen checker skips the doxygen inspection because $curr_file is located in the \"$SKIP_CI_PATHS_FORMAT\"."
             continue
         fi
-    
+
         echo "[DEBUG] The current file name is (${curr_file}). "
         # Handle only text files in case that there are lots of files in one commit.
         if [[ `file $curr_file | grep "ASCII text" | wc -l` -gt 0 ]]; then
             # In case of source code files: *.c|*.h|*.cpp|*.py|*.sh|*.php )
             case $curr_file in
                 # In case of C/C++ code
-                *.c|*.h|*.cpp|*.hpp )
+                *.c|*.h|*.cc|*.hh|*.cpp|*.hpp )
                     echo "[DEBUG] ( $curr_file ) file is source code with the text format."
                     doxygen_lang="doxygen-cncpp"
                     # Append a doxgen rule step by step


### PR DESCRIPTION
This patch adds missing extensions for cpp source codes
in doxygen pre-build checking.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
