### PR TITLE
Added  how to fix  the "gbs build" failure

### DIFF
--- a/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
@@ -20,6 +20,12 @@
 # @see      https://github.com/nnsuite/TAOS-CI
 # @see      https://source.tizen.org/documentation/reference/git-build-system
 # @author   Geunsik Lim <geunsik.lim@samsung.com>
+# @note
+# If the "gbs build" command based on the QEMU/ARM facility is broken, please run "reboot" command,
+# Or run the below statements to avoid the "reboot" procedure. 
+# https://wiki.tizen.org/OSDev/qemu-accel
+# $ echo -1 | sudo tee /proc/sys/fs/binfmt_misc/qemu-arm
+
 
 # @brief [MODULE] ${BOT_NAME}/pr-postbuild-build-tizen-wait-queue
 function pr-postbuild-build-tizen-wait-queue(){


### PR DESCRIPTION
This commit is to append an annotation to describe how to fix the "gbs build" failure due to a broken QEMU ARM.
If the QEMU facility of "gbs build" command is broken, please run "reboot" command,
Or run the below statements to avoid the "reboot" procedure. 
https://wiki.tizen.org/OSDev/qemu-accel
$ echo -1 | sudo tee /proc/sys/fs/binfmt_misc/qemu-arm

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---