### PR TITLE
[Fix/Doxygen] Fix a wrong message from failure of doxygen tag checking

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
@@ -2,7 +2,7 @@
 
 ##
 # Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -34,6 +34,7 @@ function pr-prebuild-doxygen-tag(){
     # Inspect all *.patch files that are fetched from a commit file
     FILELIST=`git show --pretty="format:" --name-only --diff-filter=AMRC`
     check_result="skip"
+    latest_failed_file=""
     for curr_file in ${FILELIST}; do
         # if a current file is located in $SKIP_CI_PATHS_FORMAT folder, let's skip the inspection process
         if [[ "$curr_file" =~ ($SKIP_CI_PATHS_FORMAT)$ ]]; then
@@ -54,54 +55,55 @@ function pr-prebuild-doxygen-tag(){
                     doxygen_basic_rules="@file @brief" # @file and @brief to inspect file
                     doxygen_advanced_rules="@author @bug" # @author, @bug to inspect file, @brief for to inspect function
 
-                    # When a current file is a source code, 
+                    # When a current file is a source code,
                     # change a default value of $check_result from 'skip' to 'success'
                     if [[ $check_result == "skip" ]]; then
                         check_result="success"
                     fi
-    
+
                     # Apply advanced doxygen rule if pr_doxygen_check_level=1 in config-environment.sh
                     if [[ $pr_doxygen_check_level == 1 ]]; then
                         doxygen_basic_rules="$doxygen_basic_rules $doxygen_advanced_rules"
                     fi
-    
+
                     for word in $doxygen_basic_rules
                     do
                         # echo "[DEBUG] $doxygen_lang: doxygen tag for current $doxygen_lang code is $word."
                         doxygen_rule_compare_count=`cat ${curr_file} | grep "$word" | wc -l`
                         doxygen_rule_expect_count=1
-    
+
                         # Doxygen_rule_compare_count: real number of Doxygen tags in a file
                         # Doxygen_rule_expect_count: required number of Doxygen tags
                         if [[ $doxygen_rule_compare_count -lt $doxygen_rule_expect_count ]]; then
                             echo "[ERROR] $doxygen_lang: failed. file name: $curr_file, $word tag is required at the top of file"
                             check_result="failure"
                             global_check_result="failure"
+                            latest_failed_file=$curr_file
                         fi
                     done
-    
+
                     # Checking tags for each function
                     if [[ $pr_doxygen_check_level == 1 ]]; then
                         declare -i idx=0
                         function_positions="" # Line number of functions.
                         structure_positions="" # Line number of structure.
-    
+
                         # Find line number of functions using ctags, and append them.
                         while IFS='' read -r line || [[ -n "$line" ]]; do
                             temp=`echo $line | cut -d ' ' -f3` # line number of function place 3rd field when divided into ' '
                             function_positions="$function_positions $temp "
                         done < <(ctags -x --c-kinds=f $curr_file) # "--c-kinds=f" mean find function
-    
+
                         # Find line number of structure using ctags, and append them.
                         while IFS='' read -r line || [[ -n "$line" ]]; do
                             temp=`echo $line | cut -d ' ' -f3` # line number of structure place 3rd field when divided into ' '
                             structure_positions="$structure_positions $temp "
                         done < <(ctags -x --c-kinds=sc $curr_file) # "--c-kinds=sc" mean find 's'truct and 'c'lass
-    
+
                         # Checking committed file line by line for detailed hints when missing Doxygen tags.
                         while IFS='' read -r line || [[ -n "$line" ]]; do
                             idx+=1
-    
+
                             # Check if a function has @brief tag or not.
                             # To pass correct line number not sub number, keep space " $idx ".
                             # ex) want to pass 143 not 14, 43, 1, 3, 4
@@ -109,8 +111,9 @@ function pr-prebuild-doxygen-tag(){
                                 echo "[ERROR] File name: $curr_file, $idx line, `echo $line | cut -d ' ' -f1` function needs @brief tag "
                                 check_result="failure"
                                 global_check_result="failure"
+                                latest_failed_file=$curr_file
                             fi
-    
+
                             # Check if a structure has @brief tag or not.
                             # To pass correct line number not sub number, keep space " $idx ".
                             # For example, we want to pass 143 not 14, 43, 1, 3, and 4.
@@ -118,8 +121,9 @@ function pr-prebuild-doxygen-tag(){
                                 echo "[ERROR] File name: $curr_file, $idx line, structure needs @brief tag "
                                 check_result="failure"
                                 global_check_result="failure"
+                                latest_failed_file=$curr_file
                             fi
-    
+
                             # Find brief tag in the comments between the codes.
                             if [[ $line =~  "@brief" ]]; then
                                 brief=1
@@ -127,7 +131,7 @@ function pr-prebuild-doxygen-tag(){
                             elif [[ $line != *"*"*  && ( $line =~ ";" || $line =~ "}" || $line =~ "#") ]]; then
                                 brief=0
                             fi
-    
+
                             # Check a comment statement that begins with '/*'.
                             # Note that doxygen does not recognize a comment  statement that start with '/*'.
                             # Let's skip the doxygen tag inspection such as "/**" in case of a single line comment.
@@ -135,15 +139,17 @@ function pr-prebuild-doxygen-tag(){
                                 echo "[ERROR] File name: $curr_file, $idx line, Doxygen or multi line comments should begin with /**"
                                 check_result="failure"
                                 global_check_result="failure"
+                                latest_failed_file=$curr_file
                             fi
-    
+
                             # Check the doxygen tag written in upper case beacuase doxygen cannot use upper case tag such as '@TODO'.
                             if [[ $line =~ "@"[A-Z] ]]; then
                                 echo "[ERROR] File name: $curr_file, $idx line, The doxygen tag sholud be written in lower case."
                                 check_result="failure"
                                 global_check_result="failure"
+                                latest_failed_file=$curr_file
                             fi
-    
+
                         done < "$curr_file"
                     fi
                     ;;
@@ -156,7 +162,7 @@ function pr-prebuild-doxygen-tag(){
                     doxygen_rule_num=0
                     doxygen_rule_all=0
 
-                    # When a current file is a source code, 
+                    # When a current file is a source code,
                     # change a default value of $check_result from 'skip' to 'success'
                     if [[ $check_result == "skip" ]]; then
                         check_result="success"
@@ -173,6 +179,7 @@ function pr-prebuild-doxygen-tag(){
                         echo "[ERROR] $doxygen_lang: failed. file name: $curr_file, ($doxygen_rule_num)/$doxygen_rule_all tags are found."
                         check_result="failure"
                         global_check_result="failure"
+                        latest_failed_file=$curr_file
                         break
                     else
                         echo "[DEBUG] $doxygen_lang: passed. file name: $curr_file, ($doxygen_rule_num)/$doxygen_rule_all tags are found."
@@ -184,7 +191,7 @@ function pr-prebuild-doxygen-tag(){
             esac
         fi
     done
-    
+
     if [[ $check_result == "success" ]]; then
         echo "[DEBUG] Passed. Doxygen documentation."
         message="Successfully the Doxygen checker is passed."
@@ -197,13 +204,13 @@ function pr-prebuild-doxygen-tag(){
         echo "[ERROR] Failed. Doxygen documentation."
         message="Oooops. The Doxygen checker is failed. Please write a Doxygen document in your code."
         cibot_report $TOKEN "failure" "${BOT_NAME}/pr-prebuild-doxygen-tag" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-    
+
         # inform a PR submitter of a hint message in more detail
-        message=":octocat: **cibot**: $user_id, **$curr_file** does not include Doxygen tags such as **$doxygen_basic_rules**. You must include the Doxygen tags in the source code."
+        message=":octocat: **cibot**: $user_id, **$latest_failed_file** does not include Doxygen tags such as **$doxygen_basic_rules**. You must include the Doxygen tags in the source code."
         message="$message Please refer to a Doxygen manual at"
         message="$message http://github.com/nnsuite/TAOS-CI/blob/master/ci/doc/doxygen-documentation.md"
         cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
-    
+
     fi
 }
 


### PR DESCRIPTION
This patch fixes a wrong message from failure of doxygen tag checking.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped