### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 # This is a comment. Each line is a file pattern followed by one or more owners.
 # For more details, visit https://help.github.com/articles/about-codeowners/
 #
-# Note that the current version of github.sec.samsung.net does not translate "@org/team-name",
-# although the GitHub webpage depicts how to use "@org/team-name" as well as "@username" format.
-# So, We need to append all member IDs manually to unexpected situations as follows.
+# Note that the current version of github.com (community edition) does not
+# translate "@org/team-name" correctly, although the GitHub webpage depicts how
+# to use "@org/team-name" as well as "@username" format. So, We need to append
+# all member IDs directly to avoid unexpected situations.
 
 # In order that all members of a repository are supposed to review each other
 * @nnstreamer/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527 @zhoonit


### PR DESCRIPTION
This commit is to fix an incorrect "@org/team-name" (e.g., @NNStreamer/nntrainer)
since there is no the team name that is called "@NNStreamer/nntrainer". So, we need
to replace @NNStreamer/nntrainer with @nnstreamer/nnstreamer.
For more details, please refer to the below webpage.

* NNStreamer's Teams - https://github.com/orgs/nnstreamer/teams

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---