### PR TITLE
[Fix] fix the curl command to parse the target directory

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -168,8 +168,8 @@ _cov_yellow_card=10
 _cov_red_card=50
 
 # Activate a selective PR audit to handle multiple projecst in the one GitHub repository
-# a. for enterprise edition - "patch-diff.githubusercontent.com"
-# b. for community  edition - "github.{YOUR_COMPANY_DNS}"
+# a. for enterprise edition - "github.{YOUR_COMPANY_DNS}"
+# b. for community  edition - "patch-diff.githubusercontent.com"
 # If you want to examine all PRs, declare "SELECTIVE_PR_AUDIT=0".
 # For example, if you want to activate a "doc" directory, write a "doc/" format (without "/doc/" format).
 SELECTIVE_PR_AUDIT=0


### PR DESCRIPTION
This patch fixes the curl command to parse the target directory.
It uses github api to get the list of modified files.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>