### PR TITLE
post-build-tizen/bugfix: Remove 'tee' connected to 'gbs build' via '|'

### DIFF
--- a/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-tizen.sh
@@ -52,7 +52,6 @@ function pr-postbuild-build-tizen-run-queue(){
     check_cmd_dep sudo
     check_cmd_dep curl
     check_cmd_dep gbs
-    check_cmd_dep tee
 
     # BUILD_MODE=0 : run "gbs build" command without generating debugging information.
     # BUILD_MODE=1 : run "gbs build" command with a debug file.
@@ -92,7 +91,7 @@ function pr-postbuild-build-tizen-run-queue(){
         --define "__ros_verify_enable 1" \
         --define "_pr_start_time ${input_date}" \
         --define "_skip_debug_rpm 1" \
-        --buildroot ./GBS-ROOT/  | tee ../report/build_log_${input_pr}_tizen_$1_output.txt
+        --buildroot ./GBS-ROOT/ 2> ../report/build_log_${input_pr}_tizen_$1_error.txt 1> ../report/build_log_${input_pr}_tizen_$1_output.txt
     else
         echo -e "BUILD_MODE = 0"
         # In case of x86_64 or i586


### PR DESCRIPTION
When the BUILD_MODE is set to 1, a command pipeline is used for running 'gbs build' and capturing the standard output of it using 'tee', which could return '0' even if the former 'gbs build' command fails. To fix this bug, this patch replaces the pipe, '|', between 'gbs build' and 'tee' with the redirections and removes 'tee'.

Signed-off-by: Wook Song <wook16.song@samsung.com>

See also: 
- Before applying the PR, you can see https://github.com/nnstreamer/nnstreamer-ros/pull/42 and https://github.com/nnstreamer/nnstreamer-ros/pull/44 passed the build checkers even if the tizen build is failed.
- After applying the PR, https://github.com/nnstreamer/nnstreamer-ros/pull/43 could not pass the build checker.  

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped