### PR TITLE
GenBadge/typo: Fix a typo in the heading comments

### DIFF
--- a/ci/badge/gen_badge.py
+++ b/ci/badge/gen_badge.py
@@ -9,7 +9,7 @@
 # @author Wook Song <wook16.song@samsung.com>
 # @note
 # usage :  ../badge/gen_badge.py {badge-name} {gcov-index-file} {output.svg}
-#    $ cd cd ci
+#    $ cd ci
 #    $ ../badge/gen_badge.py codecoverage ../gcov_html/index.html ../badge/codecoverage.svg
 #
 import sys


### PR DESCRIPTION
This is a trivial patch to fix a typo in the heading comments.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped