### PR TITLE
[Config] Updated config file for bazel-android module

### DIFF
--- a/ci/taos/config/config-plugins-postbuild.sh
+++ b/ci/taos/config/config-plugins-postbuild.sh
@@ -69,3 +69,10 @@ echo "[MODULE] plugins-staging: Plugin group that does not have evaluation and a
 # echo "[DEBUG] Current path: $(pwd)."
 # source ${REFERENCE_REPOSITORY}/ci/taos/plugins-staging/${postbuild_plugins[idx]}.sh
 
+
+# postbuild_plugins[++idx]="pr-postbuild-bazel-ubuntu"
+# echo "[DEBUG] ${postbuild_plugins[idx]} is started."
+# echo "[DEBUG] ${BOT_NAME}/${postbuild_plugins[idx]}: Check bazel-ubuntu"
+# echo "[DEBUG] Current path: $(pwd)."
+# source ${REFERENCE_REPOSITORY}/ci/taos/plugins-staging/${postbuild_plugins[idx]}.sh
+


### PR DESCRIPTION
This commit is to add the configuration statements to support
the Bazel-Ubuntu checker. This feature will be disabled by default
as an optional feature.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---