### PR TITLE
Add log message in PR gateway

### DIFF
--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -159,7 +159,8 @@ run_git_clone="sudo -Hu www-data git clone --reference ${REFERENCE_REPOSITORY} $
 echo -e "[DEBUG] $run_git_clone"
 $run_git_clone
 if [[ $? != 0 ]]; then
-    echo "[DEBUG] ERROR: 'git clone' command is failed because of incorrect setting of CI server." | tee -a $logfile_gateway
+    echo "[DEBUG] ERROR: 'git clone' is failed due to incorrect setting of CI server." | tee -a $logfile_gateway
+    echo "[DEBUG] ERROR: git clone --reference ${REFERENCE_REPOSITORY} $input_repo" | tee -a $logfile_gateway
     echo "[DEBUG] Please check /var/www/ permission, /var/www/html/.netrc, and /var/www/html/.gbs.conf." | tee -a $logfile_gateway
     echo "[DEBUG] current id: $(id)" | tee -a $logfile_gateway
     echo "[DEBUG] current path: $(pwd)" | tee -a $logfile_gateway


### PR DESCRIPTION
When one repository has multiple projects, the configuraiton files
of the CI sever has to be carefully described.
This commit is to display a hint message when a administrator of CI
server set-up configuration setting (e.g., /var/www/html/.....).

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---