### PR TITLE
[Clang Format] Change clang-format version

### DIFF
--- a/ci/taos/checker-pr-prebuild-async.sh
+++ b/ci/taos/checker-pr-prebuild-async.sh
@@ -69,7 +69,7 @@ check_cmd_dep wc
 check_cmd_dep cat
 check_cmd_dep basename
 check_cmd_dep tail
-check_cmd_dep clang-format-4.0
+check_cmd_dep clang-format-6.0
 check_cmd_dep cppcheck
 check_cmd_dep rpmlint
 check_cmd_dep aha

--- a/ci/taos/plugins-good/pr-prebuild-clang.sh
+++ b/ci/taos/plugins-good/pr-prebuild-clang.sh
@@ -31,12 +31,13 @@ function pr-prebuild-clang(){
     echo "########################################################################################"
     echo "[MODULE] pr-prebuild-clang: Check the code formatting style with clang-format"
     # Note that you have to install up-to-date clang-format package from llvm project.
-    # The clang-format-4.0 package includes git-clang-format as well as clang-format.
+    # The clang-format-6.0 package includes git-clang-format as well as clang-format.
+    # The clang-format-6.0 is used in Ubuntu 18.04 by default.
     # It has been included by http://archive.ubuntu.com/ubuntu/ by default since Oct-25-2017.
-    # $ sudo apt install clang-format-4.0
+    # $ sudo apt install clang-format-6.0
     # In case that we need to change clang-format with latest version, refer to https://apt.llvm.org
     CLANGFORMAT=NA
-    CLANG_COMMAND="clang-format-4.0"
+    CLANG_COMMAND="clang-format-6.0"
 
     which ${CLANG_COMMAND}
     if [[ $? -ne 0 ]]; then

--- a/ci/taos/webapp/install-packages-base.sh
+++ b/ci/taos/webapp/install-packages-base.sh
@@ -48,11 +48,11 @@ echo -e "\n\n\n########## for CI-system: Installing packages for gcov/lcov"
 sudo apt -y install lcov || func-pack-fail
 
 echo -e "\n\n\n########## for CI-system: Installing clang-format"
-echo -e "[DEBUG] You have to install clang-format-4.0 (official version) to check C++ formatting."
+echo -e "[DEBUG] You have to install clang-format-6.0 (official version) to check C++ formatting."
 if [[ -f /etc/apt/sources.list.d/clang.list ]]; then
     sudo echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" > /etc/apt/sources.list.d/clang.list
     sudo apt -y update
-    sudo apt -y install clang-format-4.0 || func-pack-fail
+    sudo apt -y install clang-format-6.0 || func-pack-fail
 fi
 
 echo -e "\n\n\n########## for CI-system: Installing packages for doxygen book"


### PR DESCRIPTION
Change clang format version from 4.0 to 6.0
ubuntu focal don't provide clang-format-4.0 as default.

Signed-off-by: Gichan Jang <gichan2.jang@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
