### PR TITLE
[Doxygen] Add option to skip definition tag @open sesame 04/21 19:30

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -87,7 +87,7 @@ pr_comment_pr_monitor=0
 # Empower CI bot to do the 'Review changes' activity (e.g., Comment, Approve, Request changes) as a reviwer
 pr_comment_review_activity=1
 
-#### Build test: Write a build type to test ex) "x86_64 i586 armv7l aarch64" 
+#### Build test: Write a build type to test ex) "x86_64 i586 armv7l aarch64"
 # Currently, this variable is declared to hande the "gbs build" command on Tizen.
 pr_build_arch_type="x86_64"
 
@@ -95,6 +95,12 @@ pr_build_arch_type="x86_64"
 # Basic = 0 (@file + @brief)
 # Advanced = 1 (Basic + "@author, @bug and functions with ctags")
 pr_doxygen_check_level=0
+
+### Check doxygen check for the definition (for non-header file)
+# Skip function defintion = 1
+# Don't skip function definition = 0
+# Note that in *.h file, function definitions are still checked
+pr_doxygen_check_skip_function_definition=0
 
 ### Check level of CPPCheck for a static analysis of C/C++ source code:
 # CPPCheck Level 0: The check level is 'err'.
@@ -146,7 +152,7 @@ RUN_QUEUE_PR_JOBS=8
 VERSION="1.5.20200925"
 
 #### Location of the GitHub repository
-# We assume that the default folder of the www-data (user-id of Apache webserver) is "/var/www/html/" folder. 
+# We assume that the default folder of the www-data (user-id of Apache webserver) is "/var/www/html/" folder.
 
 # Reference repository to speed up the exectuion time of the "git clone" command
 REFERENCE_REPOSITORY="/var/www/html/$PRJ_REPO_UPSTREAM_LOCAL/"

--- a/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
@@ -88,11 +88,17 @@ function pr-prebuild-doxygen-tag(){
                         function_positions="" # Line number of functions.
                         structure_positions="" # Line number of structure.
 
+                        local function_check_flag="f+p" # check document for function and prototype of the function
+
+                        if [[ $pr_doxygen_check_skip_function_definition == 1 && $curr_file != *.h ]]; then
+                            function_check_flag="p" # check document for only prototypes of the function for non-header file
+                        fi
+
                         # Find line number of functions using ctags, and append them.
                         while IFS='' read -r line || [[ -n "$line" ]]; do
                             temp=`echo $line | cut -d ' ' -f3` # line number of function place 3rd field when divided into ' '
                             function_positions="$function_positions $temp "
-                        done < <(ctags -x --c-kinds=f $curr_file) # "--c-kinds=f" mean find function
+                        done < <(ctags -x --c-kinds=$function_check_flag $curr_file) # "--c-kinds=f" mean find function
 
                         # Find line number of structure using ctags, and append them.
                         while IFS='' read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
- [Doxygen] Add option to skip definition tag 

```
For doxygen, there is a requirement from nntrainer repository that
doxygen function definition should not be checked if the function
definition is inside a source.

This patch implments for the requirement as an option.
`pr_doxygen_check_skip_function_definition` if this flag is turned on,
doxygen checker does not check definitions inside a sourcefile(eg,
*.cpp)

Feature:
- Add option to skip definition for non header file

Additional Fix:
- Fix a doxygen checker to check the function declaration(prototype)

**How test was done**
- Apply to nntrainer repository.
- Check doxygen book is not uglyfied due to this change.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```