### PR TITLE
[Android] Add option to set ndk-build path

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -87,7 +87,7 @@ pr_comment_pr_monitor=0
 # Empower CI bot to do the 'Review changes' activity (e.g., Comment, Approve, Request changes) as a reviwer
 pr_comment_review_activity=1
 
-#### Build test: Write a build type to test ex) "x86_64 i586 armv7l aarch64" 
+#### Build test: Write a build type to test ex) "x86_64 i586 armv7l aarch64"
 # Currently, this variable is declared to hande the "gbs build" command on Tizen.
 pr_build_arch_type="x86_64"
 
@@ -134,6 +134,9 @@ BUILD_MODE_UBUNTU=99
 BUILD_MODE_YOCTO=99
 BUILD_MODE_ANDROID=99
 
+# When BUILD_MODE_ANDROID is on, specify ANDROID_NDK_PATH to call ndk
+ANDROID_NDK_PATH=/var/www/html/ndks/android-ndk-r22b
+
 # Tizen: If each git repository must be defined by a different profile (e.g., ~/.gbs.conf),
 # The name of TIZEN_GBS_PROFILE can be given without the "profile." prefix as follows.
 # For example, [profile.tizen40_mobile] has to be declared with TIZEN_GBS_PROFILE="tizen40_mobile".
@@ -146,7 +149,7 @@ RUN_QUEUE_PR_JOBS=8
 VERSION="1.5.20200925"
 
 #### Location of the GitHub repository
-# We assume that the default folder of the www-data (user-id of Apache webserver) is "/var/www/html/" folder. 
+# We assume that the default folder of the www-data (user-id of Apache webserver) is "/var/www/html/" folder.
 
 # Reference repository to speed up the exectuion time of the "git clone" command
 REFERENCE_REPOSITORY="/var/www/html/$PRJ_REPO_UPSTREAM_LOCAL/"

--- a/ci/taos/plugins-base/pr-postbuild-build-android.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-android.sh
@@ -112,12 +112,12 @@ function pr-postbuild-build-android-run-queue(){
     source /etc/environment
 
     # Set the path about Android build tools
-    export ROOT_ANDROID_CI=/var/www/html/android
+    local ROOT_ANDROID_CI=/var/www/html/android
 
     # Android NDK
-    export ANDROID_NDK=$ROOT_ANDROID_CI/android-ndk-r12b
+    export ANDROID_NDK=$ANDROID_NDK_PATH
     export PATH=$ANDROID_NDK:$PATH
-    echo "Exporting an ANDROID_NDK path ..."
+    echo "Exporting an ANDROID_NDK path..."
     echo $PATH
     ndk-build --help
 


### PR DESCRIPTION
- [Android] Add option to set ndk-build path 

```
This patch enables setting `ndk-build` path rather than hardcoded path

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```