### PR TITLE
[Clang] Fix the extension check routine @open sesame 04/22 14:36

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-clang.sh
+++ b/ci/taos/plugins-good/pr-prebuild-clang.sh
@@ -55,14 +55,12 @@ function pr-prebuild-clang(){
     AUDITLIST=""
 
     for i in ${FILELIST}; do
-            AUDITLIST+=`echo $i | grep "\.h"`
-            AUDITLIST+=`echo $i | grep "\.hpp"`
-            AUDITLIST+=`echo $i | grep "\.hh"`
-            AUDITLIST+=`echo $i | grep "\.H"`
-            AUDITLIST+=`echo $i | grep "\.c"`
-            AUDITLIST+=`echo $i | grep "\.cpp"`
-            AUDITLIST+=`echo $i | grep "\.cc"`
-            AUDITLIST+=`echo $i | grep "\.C"`
+            AUDITLIST+=`echo $i | grep -i ".*\.h$"`
+            AUDITLIST+=`echo $i | grep -i ".*\.hpp$"`
+            AUDITLIST+=`echo $i | grep -i ".*\.hh$"`
+            AUDITLIST+=`echo $i | grep -i ".*\.c$"`
+            AUDITLIST+=`echo $i | grep -i ".*\.cpp$"`
+            AUDITLIST+=`echo $i | grep -i ".*\.cc$"`
         AUDITLIST+=' '
     done
     echo "[DEBUG] Files of source code: $AUDITLIST"


### PR DESCRIPTION
This patch fixes the extension check routine for pr-prebuild-clang.

Previously, it hasn't detected files correctly. For example,
`.clang-format` can be also detected, which should have been ignored.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [* ]Skipped
