### PR TITLE
[Doxygen] Add option for default check flag

### DIFF
--- a/ci/taos/config/config-environment.sh
+++ b/ci/taos/config/config-environment.sh
@@ -102,6 +102,13 @@ pr_doxygen_check_level=0
 # Note that in *.h file, function definitions are still checked
 pr_doxygen_check_skip_function_definition=0
 
+### set default doxygen function check flag
+# f means function definition only
+# p means function prototype only
+# f+p means function definition and prototype
+# this will be overriden for non-header files if @a pr_doxygen_check_skip_function_definition is set
+pr_doxygen_check_function_flag=f+p
+
 ### Check level of CPPCheck for a static analysis of C/C++ source code:
 # CPPCheck Level 0: The check level is 'err'.
 # CPPCheck Level 1: 'err' + 'warning,performance,unusedFunction'

--- a/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
@@ -88,7 +88,8 @@ function pr-prebuild-doxygen-tag(){
                         function_positions="" # Line number of functions.
                         structure_positions="" # Line number of structure.
 
-                        local function_check_flag="f+p" # check document for function and prototype of the function
+                        # check document for function and prototype of the function
+                        local function_check_flag=$pr_doxygen_check_function_flag || "f+p"
 
                         if [[ $pr_doxygen_check_skip_function_definition == 1 && $curr_file != *.h ]]; then
                             function_check_flag="p" # check document for only prototypes of the function for non-header file


### PR DESCRIPTION
- [Doxygen] Add option for default check flag 

```
This patch add flag to function doxygen checker

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jihoon Lee <jhoon.it.lee@samsung.com>

```