### PR TITLE
Added SPDX-License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -202,3 +202,13 @@ Copyright 2018 The TAOS-CI Authors.  All rights reserved.
    See the License for the specific language governing permissions and
    limitations under the License.
 
+
+----------------------------------------------------------------
+Note:
+Individual files contain the following tag instead of the full license text.
+
+              SPDX-License-Identifier: APACHE-2.0-only
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/
+

--- a/ci/taos/checker-issue-comment.sh
+++ b/ci/taos/checker-issue-comment.sh
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
-
-##
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-## 
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ## @file   checker-issue-comment.sh
 ## @brief  An issue facility to comment automatically whenever issue happens .

--- a/ci/taos/checker-pr-comment.sh
+++ b/ci/taos/checker-pr-comment.sh
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
-
-##
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-## 
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ##
 ## @file  checker-pr-comment.sh

--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
-
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ## @file     checker-pr-gateway.sh
 ## @brief    A PR gateway to control two PR checkers such as prebuild and postbuild

--- a/ci/taos/checker-pr-postbuild-async.sh
+++ b/ci/taos/checker-pr-postbuild-async.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
-
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ## @file        checker-pr-postbuild-async.sh
 ## @brief       It executes a build test whenever a PR is submitted.

--- a/ci/taos/checker-pr-prebuild-async.sh
+++ b/ci/taos/checker-pr-prebuild-async.sh
@@ -1,16 +1,5 @@
 #!/usr/bin/env bash
-
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-## 
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ## @file    checker-pr-prebuild-async.sh
 ## @brief   It checks format rules whenever a PR is submitted.

--- a/ci/taos/common/api_collection.sh
+++ b/ci/taos/common/api_collection.sh
@@ -1,19 +1,5 @@
 #!/usr/bin/env bash
-
-##
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
-
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ##
 ## @file   api_collection.sh

--- a/ci/taos/common/out-of-pr-killer.sh
+++ b/ci/taos/common/out-of-pr-killer.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
-
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ## @file   out-of-pr-killer.sh
 ## @auther Geunsik Lim <geunsik.lim@samsung.com>

--- a/ci/taos/common/pr-scheduler.sh
+++ b/ci/taos/common/pr-scheduler.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
-
-## Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##     http://www.apache.org/licenses/LICENSE-2.0
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ## @file  api_collection.sh
 ## @brief API collection to send webhook messages to a github server and to manage comment functions

--- a/ci/taos/plugins-base/pr-postbuild-build-android.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-android.sh
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
-
-##
-# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+## SPDX-License-Identifier: APACHE-2.0-only
 
 ##
 # @file pr-postbuild-build-android.sh

--- a/ci/taos/webhook.php
+++ b/ci/taos/webhook.php
@@ -1,18 +1,5 @@
 <?php
-
-/**
- * Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *     http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/** SPDX-License-Identifier: APACHE-2.0-only */
 
 /**
  *    @file   webhook.php


### PR DESCRIPTION
This commit is to add a SPDX-License statement.
* APACHE-2.0-only
* https://spdx.org/licenses/
* SPDX Guide:
To use this license in source code, put one of the following SPDX
tag/value pairs into a comment according to the placement
guidelines in the licensing rules documentation.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Acked-by: Gichan Jang <gichan2.jang@samsung.com>
