### PR TITLE
Fix inappropriate SPDX license tags

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -207,7 +207,7 @@ Copyright 2018 The TAOS-CI Authors.  All rights reserved.
 Note:
 Individual files contain the following tag instead of the full license text.
 
-              SPDX-License-Identifier: APACHE-2.0-only
+              SPDX-License-Identifier: Apache-2.0
 
 This enables machine processing of license information based on the SPDX
 License Identifiers that are here available: http://spdx.org/licenses/

--- a/ci/taos/checker-issue-comment.sh
+++ b/ci/taos/checker-issue-comment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ## @file   checker-issue-comment.sh
 ## @brief  An issue facility to comment automatically whenever issue happens .

--- a/ci/taos/checker-pr-comment.sh
+++ b/ci/taos/checker-pr-comment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ##
 ## @file  checker-pr-comment.sh

--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ## @file     checker-pr-gateway.sh
 ## @brief    A PR gateway to control two PR checkers such as prebuild and postbuild

--- a/ci/taos/checker-pr-postbuild-async.sh
+++ b/ci/taos/checker-pr-postbuild-async.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ## @file        checker-pr-postbuild-async.sh
 ## @brief       It executes a build test whenever a PR is submitted.

--- a/ci/taos/checker-pr-prebuild-async.sh
+++ b/ci/taos/checker-pr-prebuild-async.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ## @file    checker-pr-prebuild-async.sh
 ## @brief   It checks format rules whenever a PR is submitted.

--- a/ci/taos/common/api_collection.sh
+++ b/ci/taos/common/api_collection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ##
 ## @file   api_collection.sh

--- a/ci/taos/common/out-of-pr-killer.sh
+++ b/ci/taos/common/out-of-pr-killer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ## @file   out-of-pr-killer.sh
 ## @auther Geunsik Lim <geunsik.lim@samsung.com>

--- a/ci/taos/common/pr-scheduler.sh
+++ b/ci/taos/common/pr-scheduler.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ## @file  api_collection.sh
 ## @brief API collection to send webhook messages to a github server and to manage comment functions

--- a/ci/taos/plugins-base/pr-postbuild-build-android.sh
+++ b/ci/taos/plugins-base/pr-postbuild-build-android.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## SPDX-License-Identifier: APACHE-2.0-only
+## SPDX-License-Identifier: Apache-2.0
 
 ##
 # @file pr-postbuild-build-android.sh

--- a/ci/taos/webhook.php
+++ b/ci/taos/webhook.php
@@ -1,5 +1,5 @@
 <?php
-/** SPDX-License-Identifier: APACHE-2.0-only */
+/** SPDX-License-Identifier: Apache-2.0 */
 
 /**
  *    @file   webhook.php


### PR DESCRIPTION
APACHE-2.0-only --> Apache-2.0

Refer to "Finding #9" of https://lfscanning.org/reports/lfai/nnstreamer-2022-07-02-8eb54f0b-f36e-43ff-826f-80e9f251e17e.html

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

