### PR TITLE
[doxygen] update doxygen tag pattern

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
+++ b/ci/taos/plugins-good/pr-prebuild-doxygen-tag.sh
@@ -151,15 +151,8 @@ function pr-prebuild-doxygen-tag(){
                             fi
 
                             # Check the doxygen tag written in upper case beacuase doxygen cannot use upper case tag such as '@TODO'.
-			    # This is a simple (incorrect) method to detect.
-			    # @todo it should be able to know if it is inside a comment or not!
-                            if [[ $line =~ [\ \t]*\*[\t \t]*"@"[A-Z] ]]; then
-                                echo "[ERROR] File name: $curr_file, $idx line, The doxygen tag sholud be written in lower case." >> $report_path
-                                check_result="failure"
-                                global_check_result="failure"
-                                latest_failed_file=$curr_file
-                            fi
-                            if [[ $line =~ //[\ \t]*"@"[A-Z] ]]; then
+                            # Let's check a comment statement that begins with '//','/*' or ' *'.
+                            if  [[ ($line =~ "@"[A-Z]) && ($line == *([[:blank:]])"/*"* || $line == *([[:blank:]])"//"* || $line == *([[:blank:]])"*"*)]]; then
                                 echo "[ERROR] File name: $curr_file, $idx line, The doxygen tag sholud be written in lower case." >> $report_path
                                 check_result="failure"
                                 global_check_result="failure"


### PR DESCRIPTION
nnstreamer's tensor-transform has a CI error.
This patch updates doxygen tag pattern written in upper case.

See also #736 
Signed-off-by: Yelin Jeong <yelini.jeong@samsung.com>