### PR TITLE
[plugin] Add missing env variable in ml-api-android build

### DIFF
--- a/ci/taos/plugins-staging/pr-postbuild-build-ml-api-android.sh
+++ b/ci/taos/plugins-staging/pr-postbuild-build-ml-api-android.sh
@@ -67,6 +67,7 @@ function pr-postbuild-build-ml-api-android-run-queue(){
 
     # nnstreamer-edge root directory for build.
     git clone https://github.com/nnstreamer/nnstreamer-edge.git nnstreamer-edge-tmp
+    export NNSTREAMER_EDGE_ROOT=$(pwd)/nnstreamer-edge-tmp
 
     echo -e "[DEBUG] ML_API_ROOT is $ML_API_ROOT"
     echo -e "[DEBUG] NNSTREAMER_ROOT is $NNSTREAMER_ROOT"


### PR DESCRIPTION
- Add missing env variable NNSTREAMER_EDGE_ROOT in ml-api-android build

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
