### PR TITLE
[common] Add base branch name info

### DIFF
--- a/ci/taos/checker-pr-gateway.sh
+++ b/ci/taos/checker-pr-gateway.sh
@@ -15,6 +15,7 @@
 ##  arg4: branch name
 ##  arg5: PR number
 ##  arg6: delivery id
+##  arg7: base branch name
 ##
 ## @see variables to control the directories
 ##  $dir_ci directory is CI folder (Absolute path)
@@ -30,6 +31,7 @@ input_repo=$3
 input_branch=$4
 input_pr=$5
 input_delivery_id=$6
+input_base_branch=$7
 
 
 # Note the "source ./config/config-environment.sh" file can be called in another script
@@ -258,6 +260,6 @@ echo -e "[DEBUG] Added ${checker_name_list[-1]} module." | tee -a $logfile_gatew
 
 # Run all the modules (both the pre-build and post group) sequentially
 echo -e "[DEBUG] Running all modules" | tee -a $logfile_gateway
-run_all_checkers checker_cmd_list checker_name_list checker_logfile_list $1 $2 $3 $4 $5 $6
+run_all_checkers checker_cmd_list checker_name_list checker_logfile_list $1 $2 $3 $4 $5 $6 $7
 echo -e "[DEBUG] Completed all modules" | tee -a $logfile_gateway
 

--- a/ci/taos/checker-pr-postbuild-async.sh
+++ b/ci/taos/checker-pr-postbuild-async.sh
@@ -13,6 +13,7 @@
 ##  arg4: branch name
 ##  arg5: PR number
 ##  arg6: delivery id
+##  arg7: base branch name
 ##
 ## @see directory variables
 ##  $dir_ci       directory for webhooks (Absolute path)
@@ -36,6 +37,7 @@ input_repo=$3
 input_branch=$4
 input_pr=$5
 input_delivery_id=$6
+input_base_branch=$7
 
 # Note that the server administrator must declare variables after installing required packages.
 echo -e "[DEBUG] Importing the config-server-admistrator.sh file.\n"
@@ -271,6 +273,7 @@ echo -e "[DEBUG] Repository       : ${input_repo}"        >> ../report/build_log
 echo -e "[DEBUG] Branch name      : ${input_branch}"      >> ../report/build_log_${input_pr}_output.txt
 echo -e "[DEBUG] PR number        : ${input_pr}"          >> ../report/build_log_${input_pr}_output.txt
 echo -e "[DEBUG] X-GitHub-Delivery: ${input_delivery_id}" >> ../report/build_log_${input_pr}_output.txt
+echo -e "[DEBUG] Base branch      : ${input_base_branch}" >> ../report/build_log_${input_pr}_output.txt
 
 # Optimize size of log file (e.g., from 20MB to 1MB)
 # remove unnecessary contents that are created by resource checker

--- a/ci/taos/checker-pr-prebuild-async.sh
+++ b/ci/taos/checker-pr-prebuild-async.sh
@@ -12,6 +12,7 @@
 ##  arg4:   branch name
 ##  arg5:   PR number
 ##  arg6:   delivery id
+##  arg7: base branch name
 ##
 ## @see variables to control the directories
 ##  $dir_ci       directory is CI folder (Absolute path)
@@ -32,6 +33,7 @@ input_repo=$3
 input_branch=$4
 input_pr=$5
 input_delivery_id=$6
+input_base_branch=$7
 
 # Note the "source ./config/config-environment.sh" file can be called in another script
 # instead of in this file in order to support asynchronous operation from CI manager

--- a/ci/taos/webhook.php
+++ b/ci/taos/webhook.php
@@ -236,6 +236,7 @@ function github_event_handling(){
                 $delivery_id = $_SERVER['HTTP_X_GITHUB_DELIVERY'];
                 $pr_commits=$payload->pull_request->commits;
                 $pr_action=$payload->action;
+                $base_branch=$payload->pull_request->base->ref;
 
                 printf ("[DEBUG] current PR number: $pr_no \n");
                 printf ("[DEBUG] arg1) Date  : $date \n");
@@ -246,6 +247,7 @@ function github_event_handling(){
                 printf ("[DEBUG] arg6) X-GitHub-Delivery: $delivery_id \n");
                 printf ("[DEBUG] arg7) # of commits     : $pr_commits \n"); //TODO: to control "1PR/Many-commits" (e.g., cppcheck module)
                 printf ("[DEBUG] arg8) PR action        : $pr_action \n");  //TODO: to control repeated comments (e.g., same PR number)
+                printf ("[DEBUG] arg9) Base Branch      : $base_branch \n");
 
                 // Run a shell script asynchronously to avoid service timeout generated
                 // due to a long execution time.
@@ -256,7 +258,7 @@ function github_event_handling(){
                 $result=shell_exec($cmd);
                 printf ("[DEBUG] checker: checker-pr-gateway.sh is done asynchronously. \n");
                 printf ("[DEBUG] It means that checker-pr-gateway.sh is still running now.\n");
-                printf ("[DEBUG] ./checker-pr-gateway.sh $date $commit $repo $branch $pr_no $delivery_id \n");
+                printf ("[DEBUG] ./checker-pr-gateway.sh $date $commit $repo $branch $pr_no $delivery_id $base_branch \n");
 
             }
 


### PR DESCRIPTION
- Get the name of base branch from the github PR and let plugins may use it.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
