### PR TITLE
[pylint] comment only when there is a bug

### DIFF
--- a/ci/taos/plugins-good/pr-prebuild-pylint.sh
+++ b/ci/taos/plugins-good/pr-prebuild-pylint.sh
@@ -28,6 +28,7 @@ echo "##########################################################################
 echo "[MODULE] ${BOT_NAME}/pr-prebuild-pylint: Check dangerous coding constructs in source codes (*.py) with pylint"
 # investigate generated all *.patch files
 FILELIST=`git show --pretty="format:" --name-only --diff-filter=AMRC`
+check_result="success"
 for i in ${FILELIST}; do
     # skip obsolete folder
     if [[ $i =~ ^obsolete/.* ]]; then
@@ -68,12 +69,10 @@ for i in ${FILELIST}; do
                     break
                 else
                     echo "[DEBUG] $py_analysis_sw: passed. file name: $i, There are $line_count bug(s)."
-                    check_result="success"
                 fi
                 ;;
             * )
                 echo "[DEBUG] ( $i ) file can not be investigated by pylint (statid code analysis tool)."
-                check_result="skip"
                 ;;
         esac
     fi
@@ -81,18 +80,9 @@ done
 
 if [[ $check_result == "success" ]]; then
     echo "[DEBUG] Passed. static code analysis tool - pylint."
-    message="Successfully source code(s) is written without dangerous coding constructs."
+    message="Successfully source code(s) is written without dangerous coding constructs or your PR does not include python code(s)."
+
     cibot_report $TOKEN "success" "${BOT_NAME}/pr-prebuild-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM_LOCAL}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-
-    # inform PR submitter of a hint in more detail
-    message="We generate a report if there are dangerous coding constructs in your code. Please read ${CISERVER}${PRJ_REPO_UPSTREAM_LOCAL}/ci/${dir_commit}/report/${py_check_result}."
-    cibot_comment $TOKEN "$message" "$GITHUB_WEBHOOK_API/issues/$input_pr/comments"
-
-elif [[ $check_result == "skip" ]]; then
-    echo "[DEBUG] Skipped. static code analysis tool - pylint."
-    message="Skipped. Your PR does not include python code(s)."
-    cibot_report $TOKEN "success" "${BOT_NAME}/pr-prebuild-pylint" "$message" "${CISERVER}${PRJ_REPO_UPSTREAM_LOCAL}/ci/${dir_commit}/" "${GITHUB_WEBHOOK_API}/statuses/$input_commit"
-
 else
     echo "[DEBUG] Failed. static code analysis tool - pylint."
     message="Oooops. cppcheck is failed. Please, read $py_check_result for more details."


### PR DESCRIPTION
This patch adds condition to cibot comments only when there is a bug.
This PR prevents TAOS-CI makes comment like [this](https://github.com/nnstreamer/nnstreamer/pull/4233#issuecomment-1705023126)

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped